### PR TITLE
Add State class and StateType enum for system management

### DIFF
--- a/src/main/java/seedu/duke/data/state/State.java
+++ b/src/main/java/seedu/duke/data/state/State.java
@@ -1,0 +1,18 @@
+package seedu.duke.data.state;
+
+public class State {
+    private int state;
+
+    public State(int state) {
+        this.state = state;
+    }
+
+    public int getState() {
+        return state;
+    }
+
+    public void setState(int state) {
+        this.state = state;
+    }
+}
+

--- a/src/main/java/seedu/duke/data/state/StateType.java
+++ b/src/main/java/seedu/duke/data/state/StateType.java
@@ -1,0 +1,6 @@
+package seedu.duke.data.state;
+
+public enum StateType {
+    MAIN_STATE,
+    TASK_STATE
+}


### PR DESCRIPTION
MediTask lacked a way to track current state, making it hard to handle state transitions and state-specific command logic.

Changes made:
*Created State class to hold and manage the current state of the
  system.
*Added StateType enum to represent different states: MAIN_STATE and
  TASK_STATE.
*Provides a flexible way to handle state transitions and state-
  specific command logic.

This change lays the foundation for better command validation based on the system state.