### PR TITLE
Refactor State class to use StateType enum for clarity

### DIFF
--- a/src/main/java/seedu/duke/data/state/State.java
+++ b/src/main/java/seedu/duke/data/state/State.java
@@ -1,18 +1,19 @@
 package seedu.duke.data.state;
 
-public class State {
-    private int state;
+import static seedu.duke.data.state.StateType.MAIN_STATE;
 
-    public State(int state) {
-        this.state = state;
+public class State {
+    private StateType state;
+
+    public State(StateType state) {
+        this.state = MAIN_STATE;
     }
 
-    public int getState() {
+    public StateType getState() {
         return state;
     }
 
-    public void setState(int state) {
+    public void setState(StateType state) {
         this.state = state;
     }
 }
-


### PR DESCRIPTION
The State class previously used an int to represent state, which limited type safety and made it less clear what each state value represented.

Changes made:
* Replaced int-based state representation with StateType enum.
* Updated constructor, getter, and setter methods to use StateType.

These changes improve readability, type safety, and alignment with the intended use of enumerations for representing different states.