### PR TITLE
Update Parser to interact with new StateType enum

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -18,6 +18,11 @@ import static java.lang.Integer.parseInt;
 
 public class Parser {
     private static final Logger logger = Logger.getLogger("Parser");
+
+    static {
+        logger.setLevel(Level.SEVERE); // Only show warnings and errors
+    }
+
     String line;
     State state;
 
@@ -25,7 +30,8 @@ public class Parser {
         this.line = line;
         this.state = state;
         logger.log(Level.INFO, "Starting Parser Class...");
-        assert state == 0 || state == 1 : "state should be 0 or 1";
+        assert state.getState() == StateType.MAIN_STATE
+                || state.getState() == StateType.TASK_STATE : "state should be 0 or 1";
     }
     public Command parseCommand() {
         if (line == null || line.isEmpty()){

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -1,33 +1,41 @@
 package seedu.duke.parser;
 import org.junit.jupiter.api.Test;
 import seedu.duke.commands.Command;
+import seedu.duke.data.state.State;
+import seedu.duke.data.state.StateType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ParserTest {
     @Test
     public void parseCommandAdd() {
-        Command returnedCommand = new Parser("add Tom",0).parseCommand();
+        State mainState = new State(StateType.MAIN_STATE);
+        Command returnedCommand = new Parser("add Tom", mainState).parseCommand();
         assertEquals(true, returnedCommand != null);
     }
 
     @Test
     public void parseCommandList() {
-        Command returnedCommand = new Parser("add Tom",0).parseCommand();
-        assertEquals(true, returnedCommand != null);
+        State mainState = new State(StateType.MAIN_STATE);
+        Command returnedCommand = new Parser("list", mainState).parseCommand();
+        assertNotNull(returnedCommand);
 
-        Command returnedCommand1 = new Parser("add Tom",1).parseCommand();
-        assertEquals(true, returnedCommand1 != null);
+        State taskState = new State(StateType.TASK_STATE);
+        Command returnedCommand1 = new Parser("list", taskState).parseCommand();
+        assertNotNull(returnedCommand1);
     }
 
     @Test
     public void parseCommandDel() {
-        Command returnedCommand = new Parser("delete 0",0).parseCommand();
-        assertEquals(true, returnedCommand != null);
+        State mainState = new State(StateType.MAIN_STATE);
+        Command returnedCommand = new Parser("delete 0", mainState).parseCommand();
+        assertNotNull(returnedCommand);
 
-        Command returnedCommand1 = new Parser("delete Tom",0).parseCommand();
+        Command returnedCommand1 = new Parser("delete Tom", mainState).parseCommand();
         try{
-            assertEquals(false, returnedCommand1 != null);
+            assertNull(returnedCommand1);
         } catch(Exception e){
             assertEquals("Non-Numerical Error", e.getMessage());
         }
@@ -35,12 +43,13 @@ public class ParserTest {
 
     @Test
     public void parseCommandSelect() {
-        Command returnedCommand = new Parser("select 0",0).parseCommand();
-        assertEquals(true, returnedCommand != null);
+        State mainState = new State(StateType.MAIN_STATE);
+        Command returnedCommand = new Parser("select 0",mainState).parseCommand();
+        assertNotNull(returnedCommand);
 
-        Command returnedCommand1 = new Parser("select Tom",0).parseCommand();
+        Command returnedCommand1 = new Parser("select Tom",mainState).parseCommand();
         try{
-            assertEquals(false, returnedCommand1 != null);
+            assertNull(returnedCommand1);
         } catch(Exception e){
             assertEquals("Non-Numerical Error", e.getMessage());
         }
@@ -48,10 +57,11 @@ public class ParserTest {
 
     @Test
     public void parseCommandMark() {
-        Command returnedCommand = new Parser("mark 0",0).parseCommand();
-        assertEquals(true, returnedCommand != null);
+        State taskState = new State(StateType.TASK_STATE);
+        Command returnedCommand = new Parser("mark 0", taskState).parseCommand();
+        assertNotNull(returnedCommand);
 
-        Command returnedCommand1 = new Parser("mark Tom",0).parseCommand();
+        Command returnedCommand1 = new Parser("mark Tom",taskState).parseCommand();
         try{
             assertEquals(false, returnedCommand1 != null);
         } catch(Exception e){
@@ -61,10 +71,11 @@ public class ParserTest {
 
     @Test
     public void parseCommandUnmark() {
-        Command returnedCommand = new Parser("mark 0",0).parseCommand();
+        State taskState = new State(StateType.TASK_STATE);
+        Command returnedCommand = new Parser("mark 0",taskState).parseCommand();
         assertEquals(true, returnedCommand != null);
 
-        Command returnedCommand1 = new Parser("mark Tom",0).parseCommand();
+        Command returnedCommand1 = new Parser("mark Tom", taskState).parseCommand();
         try{
             assertEquals(false, returnedCommand1 != null);
         } catch(Exception e){


### PR DESCRIPTION
The Parser was designed to handle states using an int representation, which is incompatible with the new State class using the StateType enum.

Changes made:
* Modified Parser logic to parse and convert input into StateType.
* Updated state handling logic to work with the new StateType enum.

These changes ensure that the Parser integrates seamlessly with the StateType enum, enhancing type safety and improving state management expressiveness.