### PR TITLE
Add MANIFEST.MF file for JAR creation

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: seedu.duke.MediTask
+


### PR DESCRIPTION
Previously, the project did not include a MANIFEST.MF file, which is required to create a runnable JAR.

- Created MANIFEST.MF and set Manifest-Version to 1.0.
- Added seedu.duke.MediTask as the main class for application entry.

This addition ensures that the project can now be packaged into a runnable JAR file with the correct entry point.