### PR TITLE
Enable assertions in Gradle build configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ checkstyle {
     toolVersion = '10.2'
 }
 
-run{
+run {
     standardInput = System.in
+    enableAssertions = true
+    jvmArgs = ["-ea"]  // Explicitly enable assertions in the JVM
 }


### PR DESCRIPTION
Previously, the project did not explicitly enable assertions in the JVM, which could lead to missed assertion checks during runtime.

Changes Made:
- Added enableAssertions = true to ensure that assertions are enabled by default.
- Updated jvmArgs to include the "-ea" flag, explicitly enabling assertions in the JVM.

These changes ensure that assertion checks are active, improving runtime validation for debugging and correctness.