### PR TITLE
Add comprehensive unit tests for patient commands

### DIFF
--- a/src/test/java/seedu/duke/commands/PatientCommandTest.java
+++ b/src/test/java/seedu/duke/commands/PatientCommandTest.java
@@ -3,20 +3,82 @@ package seedu.duke.commands;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import seedu.duke.data.hospital.Hospital;
+import seedu.duke.data.state.State;
+import seedu.duke.data.state.StateType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PatientCommandTest {
     private Hospital hospital;
+    private State state;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         hospital = new Hospital();
+        state = new State(StateType.MAIN_STATE);
     }
 
+    private void addPatients(String... names) {
+        for (String name : names) {
+            hospital.addPatient(name);
+        }
+    }
+
+    private CommandResult executeSelectCommand(int index) {
+        SelectPatientCommand selectCommand = new SelectPatientCommand(index, state);
+        selectCommand.setHospital(hospital);
+        return selectCommand.execute();
+    }
 
     @Test
-    public void testFindPatientCommandNoMatch() {
+    public void testAddPatientCommand_success_addsPatientSuccessfully() throws Hospital.PatientNotFoundException {
+        AddPatientCommand addPatientCommand = new AddPatientCommand("Alice");
+        addPatientCommand.setHospital(hospital);
+        CommandResult result = addPatientCommand.execute();
+
+        assertEquals("New patient added: Alice", result.getFeedbackToUser());
+        assertEquals(1, hospital.getSize());
+        assertEquals("Alice", hospital.getPatient(0).getName());
+    }
+
+    @Test
+    public void testAddPatientCommand_duplicatePatient_returnsDuplicateMessage() {
+        hospital.addPatient("Alice");
+
+        AddPatientCommand addDuplicateCommand = new AddPatientCommand("Alice");
+        addDuplicateCommand.setHospital(hospital);
+        CommandResult result = addDuplicateCommand.execute();
+
+        assertEquals("This patient already exists in the hospital", result.getFeedbackToUser());
+        assertEquals(1, hospital.getSize());
+    }
+
+    @Test
+    public void testAddPatientCommand_blankName_throwsAssertionError() {
+        AddPatientCommand addPatientCommand = new AddPatientCommand("");
+        addPatientCommand.setHospital(hospital);
+
+        assertThrows(AssertionError.class, addPatientCommand::execute, "Patient name should not be null or empty");
+        assertEquals(0, hospital.getSize());
+    }
+
+    @Test
+    public void testFindPatientCommand_withMatch_returnsMatchingPatients() {
+        hospital.addPatient("Alice");
+        hospital.addPatient("Bob");
+
+        FindPatientCommand findPatientCommand = new FindPatientCommand("alice");
+        findPatientCommand.setHospital(hospital);
+        CommandResult result = findPatientCommand.execute();
+
+        String expectedOutput = "Here are the matching patients in your list: \n1. Alice\n";
+        assertEquals(expectedOutput, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void testFindPatientCommand_noMatch_returnsNoMatchMessage() {
         hospital.addPatient("Alice");
 
         FindPatientCommand findPatientCommand = new FindPatientCommand("charlie");
@@ -26,4 +88,139 @@ class PatientCommandTest {
         assertEquals("There are no matching patients in your list.", result.getFeedbackToUser());
     }
 
+    @Test
+    public void testFindPatientCommand_caseInsensitive_returnsMatchingPatients() {
+        hospital.addPatient("Alice");
+
+        FindPatientCommand findPatientCommand = new FindPatientCommand("ALICE");
+        findPatientCommand.setHospital(hospital);
+        CommandResult result = findPatientCommand.execute();
+
+        String expectedOutput = "Here are the matching patients in your list: \n1. Alice\n";
+        assertEquals(expectedOutput, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void testListPatientCommand_withPatients_displaysPatientList() {
+        hospital.addPatient("Alice");
+        hospital.addPatient("Bob");
+
+        ListPatientCommand listPatientCommand = new ListPatientCommand();
+        listPatientCommand.setHospital(hospital);
+        CommandResult result = listPatientCommand.execute();
+
+        String expectedOutput = "Here are the patients in your list!";
+        assertEquals(expectedOutput, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void testListPatientCommand_emptyList_displaysEmptyMessage() {
+        ListPatientCommand listPatientCommand = new ListPatientCommand();
+        listPatientCommand.setHospital(hospital);
+        CommandResult result = listPatientCommand.execute();
+
+        assertEquals("The patient list is currently empty!", result.getFeedbackToUser());
+    }
+
+    @Test
+    public void testDeletePatientCommand_success_deletesPatient() {
+        hospital.addPatient("Alice");
+
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(1);
+        deletePatientCommand.setHospital(hospital);
+        CommandResult result = deletePatientCommand.execute();
+
+        assertEquals("Deleted patient: Alice", result.getFeedbackToUser());
+        assertEquals(0, hospital.getSize());
+    }
+
+    @Test
+    public void testDeletePatientCommand_invalidIndex_returnsNotFoundMessage() {
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(1);
+        deletePatientCommand.setHospital(hospital);
+        CommandResult result = deletePatientCommand.execute();
+
+        assertEquals("Patient not found in the list!", result.getFeedbackToUser());
+    }
+
+    @Test
+    public void testDeletePatientCommand_outOfBoundsIndex_returnsNotFoundMessage() {
+        hospital.addPatient("Alice");
+
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(2);
+        deletePatientCommand.setHospital(hospital);
+        CommandResult result = deletePatientCommand.execute();
+
+        assertEquals("Patient not found in the list!", result.getFeedbackToUser());
+    }
+
+    @Test
+    public void testSelectPatientCommand_success_changesState() throws Hospital.PatientNotFoundException {
+        addPatients("Alice", "Bob");
+
+        CommandResult result = executeSelectCommand(1);
+
+        assertEquals("Selected patient: Alice", result.getFeedbackToUser());
+        assertEquals(StateType.TASK_STATE, state.getState());
+    }
+
+    @Test
+    public void testSelectPatientCommand_selectLastPatient_changesState() throws Hospital.PatientNotFoundException {
+        addPatients("Alice", "Bob", "Charlie");
+
+        CommandResult result = executeSelectCommand(3);
+
+        assertEquals("Selected patient: Charlie", result.getFeedbackToUser());
+        assertEquals(StateType.TASK_STATE, state.getState());
+    }
+
+    @Test
+    public void testSelectPatientCommand_invalidIndexOutOfBounds_returnsNotFoundMessage() {
+        addPatients("Alice", "Bob", "Charlie");
+
+        CommandResult result = executeSelectCommand(4);
+
+        assertEquals("Patient not found in the list!", result.getFeedbackToUser());
+        assertEquals(StateType.MAIN_STATE, state.getState());
+    }
+
+    @Test
+    public void testSelectPatientCommand_invalidIndexNegative_throwsAssertionError() {
+        SelectPatientCommand selectCommand = new SelectPatientCommand(-1, state);
+        selectCommand.setHospital(hospital);
+
+        AssertionError thrown = assertThrows(AssertionError.class, selectCommand::execute,
+                "Expected execute() to throw an AssertionError for negative index.");
+        assertTrue(thrown.getMessage().contains("Index should be non-negative"));
+    }
+
+    @Test
+    public void testSelectPatientCommand_invalidIndexZero_throwsAssertionError() {
+        addPatients("Alice");
+
+        AssertionError thrown = assertThrows(AssertionError.class, () -> executeSelectCommand(0),
+                "Expected execute() to throw an AssertionError for zero index.");
+
+        assertTrue(thrown.getMessage().contains("Index should be non-negative"));
+    }
+
+    @Test
+    public void testSelectPatientCommand_emptyHospital_returnsNotFoundMessage() {
+        CommandResult result = executeSelectCommand(1);
+
+        assertEquals("Patient not found in the list!", result.getFeedbackToUser());
+        assertEquals(StateType.MAIN_STATE, state.getState());
+    }
+
+    @Test
+    public void testSelectPatientCommand_nullState_throwsAssertionError() {
+        addPatients("Alice");
+
+        SelectPatientCommand selectCommand = new SelectPatientCommand(1, null);
+        selectCommand.setHospital(hospital);
+
+        AssertionError thrown = assertThrows(AssertionError.class, selectCommand::execute,
+                "Expected execute() to throw an AssertionError for null state.");
+        assertTrue(thrown.getMessage().contains("State object should not be null"));
+    }
 }

--- a/src/test/java/seedu/duke/commands/PatientCommandTest.java
+++ b/src/test/java/seedu/duke/commands/PatientCommandTest.java
@@ -20,9 +20,9 @@ class PatientCommandTest {
         state = new State(StateType.MAIN_STATE);
     }
 
-    private void addPatients(String... names) {
-        for (String name : names) {
-            hospital.addPatient(name);
+    private void addPatients(String[] names, String[] nrics) {
+        for (int i = 0; i < names.length; i++) {
+            hospital.addPatient(names[i], nrics[i]);
         }
     }
 
@@ -34,20 +34,20 @@ class PatientCommandTest {
 
     @Test
     public void testAddPatientCommand_success_addsPatientSuccessfully() throws Hospital.PatientNotFoundException {
-        AddPatientCommand addPatientCommand = new AddPatientCommand("Alice");
+        AddPatientCommand addPatientCommand = new AddPatientCommand("Alice", "S1234567A");
         addPatientCommand.setHospital(hospital);
         CommandResult result = addPatientCommand.execute();
 
-        assertEquals("New patient added: Alice", result.getFeedbackToUser());
+        assertEquals("New patient added: Alice [S1234567A]", result.getFeedbackToUser());
         assertEquals(1, hospital.getSize());
         assertEquals("Alice", hospital.getPatient(0).getName());
     }
 
     @Test
     public void testAddPatientCommand_duplicatePatient_returnsDuplicateMessage() {
-        hospital.addPatient("Alice");
+        hospital.addPatient("Alice", "S1234567A");
 
-        AddPatientCommand addDuplicateCommand = new AddPatientCommand("Alice");
+        AddPatientCommand addDuplicateCommand = new AddPatientCommand("Alice", "S1234567A");
         addDuplicateCommand.setHospital(hospital);
         CommandResult result = addDuplicateCommand.execute();
 
@@ -57,7 +57,7 @@ class PatientCommandTest {
 
     @Test
     public void testAddPatientCommand_blankName_throwsAssertionError() {
-        AddPatientCommand addPatientCommand = new AddPatientCommand("");
+        AddPatientCommand addPatientCommand = new AddPatientCommand("", "S1234567A");
         addPatientCommand.setHospital(hospital);
 
         assertThrows(AssertionError.class, addPatientCommand::execute, "Patient name should not be null or empty");
@@ -66,8 +66,8 @@ class PatientCommandTest {
 
     @Test
     public void testFindPatientCommand_withMatch_returnsMatchingPatients() {
-        hospital.addPatient("Alice");
-        hospital.addPatient("Bob");
+        hospital.addPatient("Alice", "S1234567A");
+        hospital.addPatient("Bob", "S7654321B");
 
         FindPatientCommand findPatientCommand = new FindPatientCommand("alice");
         findPatientCommand.setHospital(hospital);
@@ -79,7 +79,7 @@ class PatientCommandTest {
 
     @Test
     public void testFindPatientCommand_noMatch_returnsNoMatchMessage() {
-        hospital.addPatient("Alice");
+        hospital.addPatient("Alice", "S1234567A");
 
         FindPatientCommand findPatientCommand = new FindPatientCommand("charlie");
         findPatientCommand.setHospital(hospital);
@@ -90,7 +90,7 @@ class PatientCommandTest {
 
     @Test
     public void testFindPatientCommand_caseInsensitive_returnsMatchingPatients() {
-        hospital.addPatient("Alice");
+        hospital.addPatient("Alice", "S1234567A");
 
         FindPatientCommand findPatientCommand = new FindPatientCommand("ALICE");
         findPatientCommand.setHospital(hospital);
@@ -102,8 +102,8 @@ class PatientCommandTest {
 
     @Test
     public void testListPatientCommand_withPatients_displaysPatientList() {
-        hospital.addPatient("Alice");
-        hospital.addPatient("Bob");
+        hospital.addPatient("Alice", "S1234567A");
+        hospital.addPatient("Bob", "S7654321B");
 
         ListPatientCommand listPatientCommand = new ListPatientCommand();
         listPatientCommand.setHospital(hospital);
@@ -124,7 +124,7 @@ class PatientCommandTest {
 
     @Test
     public void testDeletePatientCommand_success_deletesPatient() {
-        hospital.addPatient("Alice");
+        hospital.addPatient("Alice", "S1234567A");
 
         DeletePatientCommand deletePatientCommand = new DeletePatientCommand(1);
         deletePatientCommand.setHospital(hospital);
@@ -145,7 +145,7 @@ class PatientCommandTest {
 
     @Test
     public void testDeletePatientCommand_outOfBoundsIndex_returnsNotFoundMessage() {
-        hospital.addPatient("Alice");
+        hospital.addPatient("Alice", "S1234567A");
 
         DeletePatientCommand deletePatientCommand = new DeletePatientCommand(2);
         deletePatientCommand.setHospital(hospital);
@@ -156,27 +156,27 @@ class PatientCommandTest {
 
     @Test
     public void testSelectPatientCommand_success_changesState() throws Hospital.PatientNotFoundException {
-        addPatients("Alice", "Bob");
+        addPatients(new String[]{"Alice", "Bob"}, new String[]{"S1234567A", "S7654321B"});
 
         CommandResult result = executeSelectCommand(1);
 
-        assertEquals("Selected patient: Alice", result.getFeedbackToUser());
+        assertEquals("Selected patient: Alice [S1234567A]", result.getFeedbackToUser());
         assertEquals(StateType.TASK_STATE, state.getState());
     }
 
     @Test
     public void testSelectPatientCommand_selectLastPatient_changesState() throws Hospital.PatientNotFoundException {
-        addPatients("Alice", "Bob", "Charlie");
+        addPatients(new String[]{"Alice", "Bob", "Charlie"}, new String[]{"S1234567A", "S7654321B", "S1111111C"});
 
         CommandResult result = executeSelectCommand(3);
 
-        assertEquals("Selected patient: Charlie", result.getFeedbackToUser());
+        assertEquals("Selected patient: Charlie [S1111111C]", result.getFeedbackToUser());
         assertEquals(StateType.TASK_STATE, state.getState());
     }
 
     @Test
     public void testSelectPatientCommand_invalidIndexOutOfBounds_returnsNotFoundMessage() {
-        addPatients("Alice", "Bob", "Charlie");
+        addPatients(new String[]{"Alice", "Bob", "Charlie"}, new String[]{"S1234567A", "S7654321B", "S1111111C"});
 
         CommandResult result = executeSelectCommand(4);
 
@@ -196,7 +196,7 @@ class PatientCommandTest {
 
     @Test
     public void testSelectPatientCommand_invalidIndexZero_throwsAssertionError() {
-        addPatients("Alice");
+        addPatients(new String[]{"Alice"}, new String[]{"S1234567A"});
 
         AssertionError thrown = assertThrows(AssertionError.class, () -> executeSelectCommand(0),
                 "Expected execute() to throw an AssertionError for zero index.");
@@ -214,7 +214,7 @@ class PatientCommandTest {
 
     @Test
     public void testSelectPatientCommand_nullState_throwsAssertionError() {
-        addPatients("Alice");
+        addPatients(new String[]{"Alice"}, new String[]{"S1234567A"});
 
         SelectPatientCommand selectCommand = new SelectPatientCommand(1, null);
         selectCommand.setHospital(hospital);


### PR DESCRIPTION
Changes made:
* Added unit tests for `AddPatientCommand`, `DeletePatientCommand`, `ListPatientCommand`, and `SelectPatientCommand` to ensure proper functionality and reliability.
* Included tests for various scenarios such as adding duplicates, handling invalid indices, ensuring state transitions, and testing assertions for invalid inputs.
* Covered edge cases like empty hospital lists and handling of out-of-bounds indices.

These changes improve the robustness of patient commands by ensuring proper behavior across multiple use cases and validating that error handling and assertions are working correctly.