### PR TITLE
Handle invalid index inputs for delete command in Parser

### DIFF
--- a/src/main/java/seedu/duke/parser/CommandParser.java
+++ b/src/main/java/seedu/duke/parser/CommandParser.java
@@ -2,6 +2,8 @@ package seedu.duke.parser;
 
 import seedu.duke.commands.Command;
 import seedu.duke.data.state.State;
+import seedu.duke.data.exception.IllegalValueException;
+
 /**
  * Represents a parser for commands in the application.
  * Implementing classes should provide the logic to parse and execute specific commands
@@ -16,6 +18,7 @@ public interface CommandParser {
      *              used to determine if the command is valid in the current context.
      * @return A {@link Command} object representing the result of the executed command
      *      or {@code null} if the command could not be executed.
+     * @throws IllegalValueException if the command input contains invalid values.
      */
-    Command execute(String line, State state);
+    Command execute(String line, State state) throws IllegalValueException;
 }

--- a/src/main/java/seedu/duke/parser/DeleteParser.java
+++ b/src/main/java/seedu/duke/parser/DeleteParser.java
@@ -3,16 +3,18 @@ package seedu.duke.parser;
 import seedu.duke.commands.Command;
 import seedu.duke.commands.DeletePatientCommand;
 import seedu.duke.commands.DeleteTaskCommand;
+import seedu.duke.data.exception.IllegalValueException;
 import seedu.duke.data.state.State;
 import seedu.duke.data.state.StateType;
 import seedu.duke.parser.parserutils.Index;
 
-import static java.lang.Integer.parseInt;
 /**
  * Parses and executes the "delete" command to remove a patient or task from the application.
  * Implements the {@link CommandParser} interface.
  */
 public class DeleteParser implements CommandParser {
+    public static final String MESSAGE_INVALID_INDEX = "Invalid input: please enter a valid number for the index.";
+
     /**
      * Executes the "delete" command by extracting the index from the input line and determining
      * whether to delete a patient or a task based on the current state.
@@ -22,15 +24,23 @@ public class DeleteParser implements CommandParser {
      *              used to determine whether the command relates to a patient or a task.
      * @return A {@link DeletePatientCommand} if in {@code MAIN_STATE},
      *      or a {@link DeleteTaskCommand} if in {@code TASK_STATE}.
+     * @throws IllegalValueException if the index provided is not a valid integer.
      */
     @Override
-    public Command execute(String line, State state) {
-        if (state.getState() == StateType.MAIN_STATE) {
-            int id = parseInt(new Index().extract(line));
-            return new DeletePatientCommand(id);
-        } else {
-            int id = parseInt(new Index().extract(line));
-            return new DeleteTaskCommand(id);
+    public Command execute(String line, State state) throws IllegalValueException {
+        try {
+            int id = Integer.parseInt(new Index().extract(line));
+
+            if (state.getState() == StateType.MAIN_STATE) {
+                return new DeletePatientCommand(id);
+            } else if (state.getState() == StateType.TASK_STATE) {
+                return new DeleteTaskCommand(id);
+            } else {
+                throw new IllegalValueException("Invalid state for delete command.");
+            }
+        } catch (NumberFormatException e) {
+            // Throw IllegalValueException if the index is not a valid integer
+            throw new IllegalValueException(MESSAGE_INVALID_INDEX);
         }
     }
 }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -4,6 +4,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import seedu.duke.commands.Command;
+import seedu.duke.data.exception.IllegalValueException;
 import seedu.duke.data.state.State;
 import seedu.duke.ui.Ui;
 
@@ -77,6 +78,9 @@ public class Parser {
             } catch (ArrayIndexOutOfBoundsException e) {
                 Ui.showToUserException("The input cannot be empty");
                 LOGGER.log(Level.WARNING, "Delete Command Error: Non-Numerical Error");
+            }catch (IllegalValueException e) {
+                Ui.showToUserException(e.getMessage());
+                LOGGER.log(Level.WARNING, "Delete Command Error: Non-Numerical Error", e);
             }
             break;
 

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -1,6 +1,7 @@
 package seedu.duke.parser;
 import org.junit.jupiter.api.Test;
 import seedu.duke.commands.Command;
+import seedu.duke.data.exception.IllegalValueException;
 import seedu.duke.data.state.State;
 import seedu.duke.data.state.StateType;
 
@@ -136,7 +137,7 @@ public class ParserTest {
      */
 
     @Test
-    public void parseCommandDel() {
+    public void parseCommandDel() throws IllegalValueException {
         State mainState = new State(StateType.MAIN_STATE);
         Command returnedCommand = new DeleteParser().execute("delete 0", mainState);
         assertEquals(true, returnedCommand != null);


### PR DESCRIPTION
Previously, the delete command did not handle non-integer inputs correctly, which could lead to errors and confusion for users.

Changes made:
* Added `IllegalValueException` handling specifically to the `delete` case in `Parser` to manage invalid index inputs.
* Updated the `delete` command’s error handling to display specific messages for invalid indices and log warnings.

These changes improve input validation for the `delete` command, ensuring clearer error messages and preventing unexpected behavior when a non-integer index is entered.