### PR TITLE
add illegal value exception to select command

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -90,6 +90,9 @@ public class Parser {
             } catch (ArrayIndexOutOfBoundsException e) {
                 Ui.showToUserException("The input cannot be empty");
                 LOGGER.log(Level.WARNING, "Select Command Error: Non-Numerical Error");
+            } catch (IllegalValueException e) {
+                Ui.showToUserException(e.getMessage());
+                LOGGER.log(Level.WARNING, "Select Command Error: {0}", e.getMessage());
             }
             break;
 

--- a/src/main/java/seedu/duke/parser/SelectParser.java
+++ b/src/main/java/seedu/duke/parser/SelectParser.java
@@ -2,6 +2,7 @@ package seedu.duke.parser;
 
 import seedu.duke.commands.Command;
 import seedu.duke.commands.SelectPatientCommand;
+import seedu.duke.data.exception.IllegalValueException;
 import seedu.duke.data.state.State;
 import seedu.duke.data.state.StateType;
 import seedu.duke.parser.parserutils.Index;
@@ -21,10 +22,14 @@ public class SelectParser implements CommandParser{
      *         if the command cannot be executed in the current state.
      */
     @Override
-    public Command execute(String line, State state) {
+    public Command execute(String line, State state) throws IllegalValueException {
         if(state.getState() == StateType.MAIN_STATE){
-            int id = parseInt(new Index().extract(line));
-            return new SelectPatientCommand(id, state);
+            try {
+                int id = parseInt(new Index().extract(line));
+                return new SelectPatientCommand(id, state);
+            } catch (NumberFormatException e) {
+                throw new IllegalValueException("Invalid Input. Please enter an integer.");
+            }
         }
         return null;
     }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -162,7 +162,7 @@ public class ParserTest {
      */
 
     @Test
-    public void parseCommandSelect() {
+    public void parseCommandSelect() throws IllegalValueException {
         State mainState = new State(StateType.MAIN_STATE);
         Command returnedCommand = new SelectParser().execute("select 0", mainState);
         assertNotNull(returnedCommand);


### PR DESCRIPTION
Now select command will throw an exception message instead of crashing the app when non integers are inputted