### PR TITLE
Fix the following issues

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -78,9 +78,12 @@ public class Parser {
             } catch (ArrayIndexOutOfBoundsException e) {
                 Ui.showToUserException("The input cannot be empty");
                 LOGGER.log(Level.WARNING, "Delete Command Error: Non-Numerical Error");
-            }catch (IllegalValueException e) {
+            } catch (IllegalValueException e) {
                 Ui.showToUserException(e.getMessage());
                 LOGGER.log(Level.WARNING, "Delete Command Error: Non-Numerical Error", e);
+            } catch (NumberFormatException e) {
+                Ui.showToUserException("The input is invalid");
+                LOGGER.log(Level.WARNING, "Mark Command Error: Non-Numerical Error");
             }
             break;
 
@@ -102,6 +105,9 @@ public class Parser {
             } catch (ArrayIndexOutOfBoundsException e) {
                 Ui.showToUserException("The input cannot be empty");
                 LOGGER.log(Level.WARNING, "Mark Command Error: Non-Numerical Error");
+            } catch (NumberFormatException e) {
+                Ui.showToUserException("The input is invalid");
+                LOGGER.log(Level.WARNING, "Mark Command Error: Non-Numerical Error");
             }
             break;
 
@@ -111,6 +117,9 @@ public class Parser {
             } catch (ArrayIndexOutOfBoundsException e) {
                 Ui.showToUserException("The input cannot be empty");
                 LOGGER.log(Level.WARNING, "Unmark Command Error: Non-Numerical Error");
+            } catch (NumberFormatException e) {
+                Ui.showToUserException("The input is invalid");
+                LOGGER.log(Level.WARNING, "Mark Command Error: Non-Numerical Error");
             }
             break;
 

--- a/src/main/java/seedu/duke/parser/parserutils/PatientName.java
+++ b/src/main/java/seedu/duke/parser/parserutils/PatientName.java
@@ -15,8 +15,8 @@ public class PatientName implements StringExtraction{
     @Override
     public String extract(String input) {
         String[] name;
-        if(input.contains("/tag ")){
-            name = input.split(" /tag ");
+        if(input.contains("/tag")){
+            name = input.split(" /tag");
         } else {
             name = new String[]{input};
         }

--- a/src/main/java/seedu/duke/parser/parserutils/TaskName.java
+++ b/src/main/java/seedu/duke/parser/parserutils/TaskName.java
@@ -16,22 +16,22 @@ public class TaskName implements StringExtraction{
     @Override
     public String extract(String input) {
         String[] name;
-        if(input.contains("/by ")){
+        if(input.contains("/by")){
             name = input.split("/by");
-        } else if(input.contains("/every ")){
+        } else if(input.contains("/every")){
             name = input.split("/every");
-        } else if(input.contains("/tag ")){
+        } else if(input.contains("/tag")){
             name = input.split("/tag");
         } else {
             name = new String[]{input};
         }
         String[] result;
         if(input.contains("deadline ")){
-            result = name[0].split("deadline ");
+            result = name[0].split("deadline");
         } else if (input.contains("repeat ")){
-            result = name[0].split("repeat ");
+            result = name[0].split("repeat");
         } else if (input.contains("todo ")){
-            result = name[0].split("todo ");
+            result = name[0].split("todo");
         } else {
             result = new String[]{input};
         }


### PR DESCRIPTION
- Mark/unmark/delete command crashes when the index is a string
- When adding a patient, typing /tag which is the tag flag, and not adding a description after the flag without a space makes the flag grouped as the patient's name.
- When adding a repeat task, typing /every which is the flag, and not adding a description after the flag without a space makes the flag grouped as the task's name.
- Solves issue #184 , #182 , #164 , #152 , #148 , #146 , #145 , #143 