### PR TITLE
Add file-based logging and adjust severity level to WARNING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ data/hospital_backup_*.json
 .classpath
 .project
 .settings/org.eclipse.buildship.core.prefs
+logs/

--- a/src/main/java/seedu/duke/MediTask.java
+++ b/src/main/java/seedu/duke/MediTask.java
@@ -11,6 +11,7 @@ import seedu.duke.data.state.StateManager;
 import seedu.duke.parser.Parser;
 import seedu.duke.storage.StorageFile;
 import seedu.duke.ui.Ui;
+import seedu.duke.data.logger.LoggerConfig;
 
 /**
  * Entry point of the MediTask program is a task management application for
@@ -21,11 +22,16 @@ public class MediTask {
 
     /** Version info of the program. */
     public static final String VERSION = "MediTask - Version 2.0";
-
     private Ui ui;
     private StorageFile storage;
     private Hospital hospital; // Load data from file
     private StateManager stageManager; // Manages the different states of the program
+
+    /** Main entry-point for the MediTask application. */
+    public static void main(String[] args) {
+        LoggerConfig.configureGlobalLogging(); // Initialize global logging
+        new MediTask().run();
+    }
 
     /** Runs the program until termination. */
     public void run() {
@@ -36,7 +42,6 @@ public class MediTask {
 
     /** Prints the Goodbye message and exits. */
     private void exit() {
-        // ui.showGoodbyeMessage();
         System.exit(0);
     }
 
@@ -47,13 +52,9 @@ public class MediTask {
     private void start() {
         ui = new Ui();
         storage = new StorageFile();
-
         stageManager = new StateManager(); // Initialize the stage manager
-
         ui.showWelcome();
-
         hospital = storage.load(); // Load data from file
-
         HospitalCommand.setHospital(hospital);
     }
 
@@ -96,12 +97,4 @@ public class MediTask {
 
         } while (!ExitCommand.isExit(command));
     }
-
-    /**
-     * Main entry-point for the java.duke.MediTask application.
-     */
-    public static void main(String[] args) {
-        new MediTask().run();
-    }
-
 }

--- a/src/main/java/seedu/duke/commands/AddPatientCommand.java
+++ b/src/main/java/seedu/duke/commands/AddPatientCommand.java
@@ -17,9 +17,7 @@ public class AddPatientCommand extends HospitalCommand {
     private String name;
     private String tag;
 
-    static {
-        logger.setLevel(Level.SEVERE); // Only show warnings and errors
-    }
+
 
     /**
      * Constructs an {@code AddPatientCommand} with the specified patient name and optional tag.
@@ -43,7 +41,7 @@ public class AddPatientCommand extends HospitalCommand {
         assert name != null && !name.isEmpty() : "Patient name should not be null or empty";
 
         if (hospital.isDuplicatePatient(name)) {
-            logger.log(Level.SEVERE, "Duplicate patient detected: {0}", name);
+            logger.log(Level.WARNING, "Duplicate patient detected: {0}", name);
             return new CommandResult(MESSAGE_DUPLICATE_PATIENT);
         }
 

--- a/src/main/java/seedu/duke/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/duke/commands/AddTaskCommand.java
@@ -17,9 +17,6 @@ public class AddTaskCommand extends Command {
     private String[] args;
     private Task toAdd = null;
 
-    static {
-        LOGGER.setLevel(Level.SEVERE); // Only show warnings and errors
-    }
 
     public AddTaskCommand(String taskType, String... parameters) {
         this.taskType = taskType;
@@ -40,16 +37,16 @@ public class AddTaskCommand extends Command {
             tasks.addTask(toAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (TaskList.DuplicateTaskException e) {
-            LOGGER.log(Level.SEVERE, "Duplicate task detected: {0}", toAdd);
+            LOGGER.log(Level.WARNING, "Duplicate task detected: {0}", toAdd);
             return new CommandResult(MESSAGE_DUPLICATE_TASK);
         } catch (Task.UnknownTaskType e) {
-            LOGGER.log(Level.SEVERE, "Invalid task type: {0}", taskType);
+            LOGGER.log(Level.WARNING, "Invalid task type: {0}", taskType);
             return new CommandResult(e.getMessage());
         } catch (Task.EmptyTaskDescription e){
-            LOGGER.log(Level.SEVERE, "Empty task description");
+            LOGGER.log(Level.WARNING, "Empty task description");
             return new CommandResult(e.getMessage());
         } catch (Task.MissingTaskArgument e) {
-            LOGGER.log(Level.SEVERE, "Missing task argument for type: {0}", taskType);
+            LOGGER.log(Level.WARNING, "Missing task argument for type: {0}", taskType);
             return new CommandResult(e.getMessage());
         }
     }

--- a/src/main/java/seedu/duke/commands/BackCommand.java
+++ b/src/main/java/seedu/duke/commands/BackCommand.java
@@ -16,9 +16,7 @@ public class BackCommand extends Command {
 
     private State state;
 
-    static {
-        logger.setLevel(Level.SEVERE); // Only show warnings and errors
-    }
+
 
     public BackCommand(State state) {
         this.state = state;

--- a/src/main/java/seedu/duke/commands/DeletePatientCommand.java
+++ b/src/main/java/seedu/duke/commands/DeletePatientCommand.java
@@ -18,10 +18,6 @@ public class DeletePatientCommand extends HospitalCommand {
 
     private int index;
 
-    static {
-        logger.setLevel(Level.SEVERE);
-    }
-
     /**
      * Constructs a {@code DeletePatientCommand} with the specified index of the patient to delete.
      * The index is adjusted to be zero-based for internal list access.
@@ -50,7 +46,7 @@ public class DeletePatientCommand extends HospitalCommand {
             // System.out.println(resultMessage);
             return new CommandResult(resultMessage);
         } catch (Hospital.PatientNotFoundException e) {
-            logger.log(Level.SEVERE, "Attempted to delete a patient at an invalid index: {0}", index);
+            logger.log(Level.WARNING, "Attempted to delete a patient at an invalid index: {0}", index);
             // System.out.println(MESSAGE_PATIENT_NOT_FOUND);
             return new CommandResult(MESSAGE_PATIENT_NOT_FOUND);
         }

--- a/src/main/java/seedu/duke/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/duke/commands/DeleteTaskCommand.java
@@ -17,9 +17,6 @@ public class DeleteTaskCommand extends Command {
         this.index = index - 1;
     }
 
-    static {
-        logger.setLevel(Level.SEVERE);
-    }
 
     @Override
     public CommandResult execute() {
@@ -30,7 +27,7 @@ public class DeleteTaskCommand extends Command {
             tasks.deleteTask(index);
             return new CommandResult(MESSAGE_SUCCESS);
         } catch (TaskList.TaskNotFoundException e) {
-            logger.log(Level.SEVERE, "Attempted to delete a task at an invalid index: {0}", index);
+            logger.log(Level.WARNING, "Attempted to delete a task at an invalid index: {0}", index);
             return new CommandResult(MESSAGE_TASK_NOT_FOUND);
         }
     }

--- a/src/main/java/seedu/duke/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/duke/commands/FindPatientCommand.java
@@ -19,9 +19,6 @@ public class FindPatientCommand extends HospitalCommand {
 
     private final String keyword;
 
-    static {
-        logger.setLevel(Level.SEVERE);
-    }
 
     /**
      * Constructs a {@code FindPatientCommand} with the specified keyword to search for.
@@ -47,7 +44,7 @@ public class FindPatientCommand extends HospitalCommand {
 
         // Check if any patients were found
         if (foundPatients.isEmpty()) {
-            logger.log(Level.SEVERE, "No matching patients found: {0}", keyword);
+            logger.log(Level.WARNING, "No matching patients found: {0}", keyword);
             return new CommandResult(MESSAGE_NO_MATCH);
         } else {
             return new CommandResult(String.format(MESSAGE_SUCCESS, foundListToString(foundPatients)));

--- a/src/main/java/seedu/duke/commands/FindTaskCommand.java
+++ b/src/main/java/seedu/duke/commands/FindTaskCommand.java
@@ -17,9 +17,7 @@ public class FindTaskCommand extends Command{
     
     private final String keyword;
 
-    static {
-        LOGGER.setLevel(Level.SEVERE); // Only show warnings and errors
-    }
+
     public FindTaskCommand(String keyword) {
         this.keyword = keyword;
     }
@@ -32,7 +30,7 @@ public class FindTaskCommand extends Command{
             ArrayList<Task> foundTasks = tasks.findTasks(keyword);
             return new CommandResult(String.format(MESSAGE_SUCCESS, foundListToString(foundTasks)));
         } catch (TaskList.TaskNotFoundException e) {
-            LOGGER.log(Level.SEVERE, "No matching tasks found: {0}", keyword);
+            LOGGER.log(Level.WARNING, "No matching tasks found: {0}", keyword);
             return new CommandResult(MESSAGE_NO_MATCH);
         } 
     }

--- a/src/main/java/seedu/duke/commands/HospitalCommand.java
+++ b/src/main/java/seedu/duke/commands/HospitalCommand.java
@@ -10,9 +10,6 @@ public abstract class HospitalCommand extends Command {
 
     private static final Logger logger = Logger.getLogger(HospitalCommand.class.getName());
 
-    static {
-        logger.setLevel(Level.SEVERE); // Only show warnings and errors
-    }
 
     public static void setHospital(Hospital hospital) {
         assert hospital != null : "Hospital instance should not be null";

--- a/src/main/java/seedu/duke/commands/ListPatientCommand.java
+++ b/src/main/java/seedu/duke/commands/ListPatientCommand.java
@@ -16,9 +16,6 @@ public class ListPatientCommand extends HospitalCommand {
 
     private static final Logger logger = Logger.getLogger(ListPatientCommand.class.getName());
 
-    static {
-        logger.setLevel(Level.SEVERE);
-    }
 
     Ui ui = new Ui();
 

--- a/src/main/java/seedu/duke/commands/ListTaskCommand.java
+++ b/src/main/java/seedu/duke/commands/ListTaskCommand.java
@@ -15,9 +15,6 @@ public class ListTaskCommand extends Command {
     
     private static final Logger logger = Logger.getLogger(ListPatientCommand.class.getName());
 
-    static {
-        logger.setLevel(Level.SEVERE);
-    }
 
     Ui ui = new Ui();
     Patient currentPatient = Hospital.getSelectedPatient();

--- a/src/main/java/seedu/duke/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/duke/commands/MarkTaskCommand.java
@@ -14,9 +14,6 @@ public class MarkTaskCommand extends Command {
 
     private final int index;
 
-    static {
-        logger.setLevel(Level.SEVERE);
-    }
 
     public MarkTaskCommand(int index) {
         this.index = index - 1;
@@ -31,7 +28,7 @@ public class MarkTaskCommand extends Command {
             tasks.markAsDone(index);
             return new CommandResult(String.format(MESSAGE_SUCCESS, tasks.getTask(index)));
         } catch (TaskList.TaskNotFoundException e) {
-            logger.log(Level.SEVERE, "Attempted to mark a task at an invalid index: {0}", index);
+            logger.log(Level.WARNING, "Attempted to mark a task at an invalid index: {0}", index);
             return new CommandResult(MESSAGE_TASK_NOT_FOUND);
         }
     }

--- a/src/main/java/seedu/duke/commands/SelectPatientCommand.java
+++ b/src/main/java/seedu/duke/commands/SelectPatientCommand.java
@@ -22,9 +22,6 @@ public class SelectPatientCommand extends HospitalCommand {
     private State state; // To hold reference to the global state object
     private int index;
 
-    static {
-        logger.setLevel(Level.SEVERE);
-    }
 
     /**
      * Constructs a {@code SelectPatientCommand} with the specified index and global state.
@@ -59,7 +56,7 @@ public class SelectPatientCommand extends HospitalCommand {
             // System.out.println(resultMessage);
             return new CommandResult(resultMessage);
         } catch (Hospital.PatientNotFoundException e) {
-            logger.log(Level.SEVERE, "Attempted to select a patient at an invalid index: {0}", index);
+            logger.log(Level.WARNING, "Attempted to select a patient at an invalid index: {0}", index);
             // System.out.println(MESSAGE_PATIENT_NOT_FOUND);
             return new CommandResult(MESSAGE_PATIENT_NOT_FOUND);
         }

--- a/src/main/java/seedu/duke/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/duke/commands/UnmarkTaskCommand.java
@@ -13,10 +13,7 @@ public class UnmarkTaskCommand extends Command {
     private static final Logger logger = Logger.getLogger(UnmarkTaskCommand.class.getName());
     
     private final int index;
-    
-    static {
-        logger.setLevel(Level.SEVERE);
-    }
+
     public UnmarkTaskCommand(int index) {
         this.index = index - 1;
     }
@@ -30,7 +27,7 @@ public class UnmarkTaskCommand extends Command {
             tasks.markAsUndone(index);
             return new CommandResult(String.format(MESSAGE_SUCCESS, tasks.getTask(index)));
         } catch (TaskList.TaskNotFoundException e) {
-            logger.log(Level.SEVERE, "Attempted to unmark a task at an invalid index: {0}", index);
+            logger.log(Level.WARNING, "Attempted to unmark a task at an invalid index: {0}", index);
             return new CommandResult(MESSAGE_TASK_NOT_FOUND);
         }
     }

--- a/src/main/java/seedu/duke/data/logger/LoggerConfig.java
+++ b/src/main/java/seedu/duke/data/logger/LoggerConfig.java
@@ -1,0 +1,51 @@
+package seedu.duke.data.logger;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+
+/**
+ * Configures global logging for the MediTask application.
+ * This setup logs all messages to a file while restricting console output
+ * to SEVERE level messages only.
+ */
+public class LoggerConfig {
+
+    public static void configureGlobalLogging() {
+        Logger rootLogger = Logger.getLogger(""); // Root logger
+
+        // Remove all existing handlers to avoid duplicate logging
+        for (var handler : rootLogger.getHandlers()) {
+            rootLogger.removeHandler(handler);
+        }
+
+        try {
+            // Set up log file path relative to the program's location
+            Path logFilePath = Paths.get("logs", "meditask.log").toAbsolutePath();
+            logFilePath.getParent().toFile().mkdirs(); // Ensure directories exist
+
+            // Set up a FileHandler to log all messages to the file
+            FileHandler fileHandler = new FileHandler(logFilePath.toString(), true); // Append mode
+            fileHandler.setFormatter(new SimpleFormatter());
+            fileHandler.setLevel(Level.ALL); // Log all levels to the file
+            rootLogger.addHandler(fileHandler);
+
+            // Set up a ConsoleHandler to log only SEVERE messages to the console
+            ConsoleHandler consoleHandler = new ConsoleHandler();
+            consoleHandler.setLevel(Level.SEVERE); // Only SEVERE messages appear in console
+            rootLogger.addHandler(consoleHandler);
+
+            // Set the global log level to the lowest level to ensure all messages are processed
+            rootLogger.setLevel(Level.ALL);
+
+        } catch (IOException e) {
+            System.err.println("Failed to set up global logging to file: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/seedu/duke/parser/AddDeadlineParser.java
+++ b/src/main/java/seedu/duke/parser/AddDeadlineParser.java
@@ -38,7 +38,7 @@ public class AddDeadlineParser implements CommandParser {
                 // Parse, validate, and format the date using DateFormat
                 by = DateFormat.validateAndParseToStandardFormat(by);
             } catch (DateParseException e) {
-                LOGGER.log(Level.SEVERE, "Invalid date/time format for deadline: {0}", by);
+                LOGGER.log(Level.WARNING, "Invalid date/time format for deadline: {0}", by);
                 return null;
             }
             return new AddTaskCommand("deadline", taskName, by, tag);

--- a/src/main/java/seedu/duke/parser/parserutils/DateFormat.java
+++ b/src/main/java/seedu/duke/parser/parserutils/DateFormat.java
@@ -25,9 +25,6 @@ public class DateFormat {
 
     private static final Logger LOGGER = Logger.getLogger(DateFormat.class.getName());
 
-    static {
-        LOGGER.setLevel(Level.SEVERE);
-    }
 
     private static final DateTimeFormatter STANDARD_DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MMM-yyyy");
     private static final DateTimeFormatter STANDARD_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm");
@@ -57,7 +54,7 @@ public class DateFormat {
 
         } catch (DateTimeParseException e) {
             showToUserException("Failed to parse date/time:" + dateStr);
-            LOGGER.log(Level.SEVERE, "Failed to parse date/time: {0}", dateStr);
+            LOGGER.log(Level.WARNING, "Failed to parse date/time: {0}", dateStr);
             throw new DateParseException(MESSAGE_INVALID_DATE_INPUT);
         }
     }


### PR DESCRIPTION
Previously, all logs were shown on console with only SEVERE messages displayed,
leaving other levels untracked. Severity levels were set too high, limiting visibility
of less critical issues.

**Changes made**:

- Created `LoggerConfig` to establish a new logging system
- Set up `FileHandler` to log all levels to `meditask.log` in logs directory
- Configured `ConsoleHandler` to show only `SEVERE` messages in console
- Updated default severity level from `SEVERE` to `WARNING`
- Removed default handlers to ensure only configured logging is applied

This update introduces a structured logging system from scratch, allowing all
log messages to be saved in a dedicated log file while limiting console output
to severe errors only. Setting the severity level to WARNING improves tracking
of application activity, capturing less critical issues without excessive severity
in console or log files, ultimately enhancing insight and reducing clutter.
