### PR TITLE
Fix mark/unmark crashes when input non-int

### DIFF
--- a/src/main/java/seedu/duke/parser/MarkParser.java
+++ b/src/main/java/seedu/duke/parser/MarkParser.java
@@ -20,10 +20,10 @@ public class MarkParser implements CommandParser{
      * @param line  The input string containing the "mark" command followed by the index of the task to be marked.
      * @param state The current state of the application, used to determine if the command can be executed.
      * @return A {@link MarkTaskCommand} if in {@code TASK_STATE}, or {@code null} if the command cannot be executed.
-          * @throws IllegalValueException 
-          */
-         @Override
-         public Command execute(String line, State state) throws IllegalValueException {
+     * @throws IllegalValueException 
+     */
+    @Override
+    public Command execute(String line, State state) throws IllegalValueException {
         if(state.getState() == StateType.TASK_STATE) {
             try {
                 int id = parseInt(new Index().extract(line));

--- a/src/main/java/seedu/duke/parser/MarkParser.java
+++ b/src/main/java/seedu/duke/parser/MarkParser.java
@@ -1,12 +1,13 @@
 package seedu.duke.parser;
 
+import static java.lang.Integer.parseInt;
+
 import seedu.duke.commands.Command;
 import seedu.duke.commands.MarkTaskCommand;
+import seedu.duke.data.exception.IllegalValueException;
 import seedu.duke.data.state.State;
 import seedu.duke.data.state.StateType;
 import seedu.duke.parser.parserutils.Index;
-
-import static java.lang.Integer.parseInt;
 /**
  * Parses and executes the "mark" command to mark a task as completed.
  * Implements the {@link CommandParser} interface.
@@ -19,12 +20,17 @@ public class MarkParser implements CommandParser{
      * @param line  The input string containing the "mark" command followed by the index of the task to be marked.
      * @param state The current state of the application, used to determine if the command can be executed.
      * @return A {@link MarkTaskCommand} if in {@code TASK_STATE}, or {@code null} if the command cannot be executed.
-     */
-    @Override
-    public Command execute(String line, State state) {
+          * @throws IllegalValueException 
+          */
+         @Override
+         public Command execute(String line, State state) throws IllegalValueException {
         if(state.getState() == StateType.TASK_STATE) {
-            int id = parseInt(new Index().extract(line));
-            return new MarkTaskCommand(id);
+            try {
+                int id = parseInt(new Index().extract(line));
+                return new MarkTaskCommand(id);
+            } catch (NumberFormatException e) {
+                throw new IllegalValueException("Invalid Input. Please enter an integer.");
+            }
         }
         return null;
     }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -114,6 +114,9 @@ public class Parser {
             } catch (ArrayIndexOutOfBoundsException e) {
                 Ui.showToUserException("The input cannot be empty");
                 LOGGER.log(Level.WARNING, "Unmark Command Error: Non-Numerical Error");
+            } catch (IllegalValueException e) {
+                Ui.showToUserException(e.getMessage());
+                LOGGER.log(Level.WARNING, "Unmark Command Error: {0}", e.getMessage());
             }
             break;
 

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -102,6 +102,9 @@ public class Parser {
             } catch (ArrayIndexOutOfBoundsException e) {
                 Ui.showToUserException("The input cannot be empty");
                 LOGGER.log(Level.WARNING, "Mark Command Error: Non-Numerical Error");
+            } catch (IllegalValueException e) {
+                Ui.showToUserException(e.getMessage());
+                LOGGER.log(Level.WARNING, "Mark Command Error: {0}", e.getMessage());
             }
             break;
 

--- a/src/main/java/seedu/duke/parser/UnmarkParser.java
+++ b/src/main/java/seedu/duke/parser/UnmarkParser.java
@@ -1,12 +1,13 @@
 package seedu.duke.parser;
 
+import static java.lang.Integer.parseInt;
+
 import seedu.duke.commands.Command;
 import seedu.duke.commands.UnmarkTaskCommand;
+import seedu.duke.data.exception.IllegalValueException;
 import seedu.duke.data.state.State;
 import seedu.duke.data.state.StateType;
 import seedu.duke.parser.parserutils.Index;
-
-import static java.lang.Integer.parseInt;
 /**
  * Parses the "unmark" command input and executes the corresponding action
  * in the application. This class is responsible for unmarking a task based on the provided ID.
@@ -19,12 +20,17 @@ public class UnmarkParser implements CommandParser{
      * @param state The current state of the application, which influences command execution.
      * @return The command object representing the unmarking action, or {@code null}
      *         if the command cannot be executed in the current state.
+     * @throws IllegalValueException 
      */
     @Override
-    public Command execute(String line, State state) {
+    public Command execute(String line, State state) throws IllegalValueException {
         if(state.getState() == StateType.TASK_STATE){
-            int id = parseInt(new Index().extract(line));
-            return new UnmarkTaskCommand(id);
+            try{
+                int id = parseInt(new Index().extract(line));
+                return new UnmarkTaskCommand(id);
+            } catch (NumberFormatException e) {
+                throw new IllegalValueException("Invalid Input. Please enter an integer.");
+            }
         }
         return null;
     }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -1,13 +1,13 @@
 package seedu.duke.parser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+
 import seedu.duke.commands.Command;
 import seedu.duke.data.exception.IllegalValueException;
 import seedu.duke.data.state.State;
 import seedu.duke.data.state.StateType;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test class for testing the behavior of different parsers in the application.
@@ -184,10 +184,11 @@ public class ParserTest {
      * Tests the parsing of a "mark" command.
      * Verifies that valid mark commands return non-null commands in the task state,
      * null commands in the main state, and throws an exception for invalid input.
-     */
-
-    @Test
-    public void parseCommandMark() {
+          * @throws IllegalValueException 
+          */
+     
+         @Test
+         public void parseCommandMark() throws IllegalValueException {
         State taskState = new State(StateType.TASK_STATE);
         Command returnedCommand = new MarkParser().execute("mark 0", taskState);
         assertEquals(true, returnedCommand != null);

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -184,11 +184,10 @@ public class ParserTest {
      * Tests the parsing of a "mark" command.
      * Verifies that valid mark commands return non-null commands in the task state,
      * null commands in the main state, and throws an exception for invalid input.
-          * @throws IllegalValueException 
-          */
+     */
      
-         @Test
-         public void parseCommandMark() throws IllegalValueException {
+    @Test
+    public void parseCommandMark() throws IllegalValueException {
         State taskState = new State(StateType.TASK_STATE);
         Command returnedCommand = new MarkParser().execute("mark 0", taskState);
         assertEquals(true, returnedCommand != null);
@@ -213,7 +212,7 @@ public class ParserTest {
      */
 
     @Test
-    public void parseCommandUnmark() {
+    public void parseCommandUnmark() throws IllegalValueException {
         State taskState = new State(StateType.TASK_STATE);
         Command returnedCommand = new UnmarkParser().execute("unmark 0",taskState);
         assertEquals(true, returnedCommand != null);


### PR DESCRIPTION
Fix #143 
Fix #152 
What changed:
- Mark/Unmark parser now catches illegal value (non-integer) and throws an exception. Parser and ParserTest were changed to accommodate this fix.