### PR TITLE
Fix for Empty or Whitespace-only Input Causing Program Crash

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -29,6 +29,13 @@ public class Parser {
      *         or the input is empty.
      */
     public Command parseCommand(String line, State state){
+        //need to check if all space or will crash
+        if (line == null || line.trim().isEmpty()) {
+            Ui.showToUserException("Input cannot be empty");
+            LOGGER.log(Level.WARNING, "Empty or whitespace-only input");
+            return null;
+        }
+
         String[] parts = line.split(" ");
 
         switch(parts[0]){


### PR DESCRIPTION
Parser now checks if line only consist of whitespace (using line.trim().isEmpty()).
This prevent the program from crashing in the next line if input is just spaces